### PR TITLE
[update]x/auth/getTransaction_getTransactions

### DIFF
--- a/src/common/cosmos-sdk-host.ts
+++ b/src/common/cosmos-sdk-host.ts
@@ -2,6 +2,7 @@ import * as request from 'request';
 import { StdSignDoc, StdFee } from '../x/auth/stdtx';
 import { Msg } from '../cosmos-sdk/tx_msg';
 import { Amino } from '../tendermint/amino';
+import { ErrorResponse } from '../cosmos-sdk/rest';
 
 /**
  * Cosmos SDK Rest APIのホスト情報を保持するオブジェクト。
@@ -24,6 +25,8 @@ export class CosmosSdkHost {
    * 登録されたurlにGETする。
    * @param path 
    * @param params 
+   * @returns Promise resolve: T, reject: ErrorResponse
+   * @see ErrorResponse
    */
   public get<T>(path: string, params?: any): Promise<T> {
     return new Promise((resolve, reject) => {
@@ -36,11 +39,11 @@ export class CosmosSdkHost {
         },
         (error, response, body) => {
           if (error) {
-            reject(error);
+            reject(JSON.parse(body, Amino.reviver) as ErrorResponse);
             return;
           }
 
-          resolve(JSON.parse(body, Amino.reviver));
+          resolve(JSON.parse(body, Amino.reviver) as T);
         }
       );
     });
@@ -50,6 +53,8 @@ export class CosmosSdkHost {
    * 登録されたurlにPOSTする。
    * @param path 
    * @param params 
+   * @returns Promise resolve: T, reject: ErrorResponse
+   * @see ErrorResponse
    */
   public post<T>(path: string, params: any): Promise<T> {
     return new Promise((resolve, reject) => {
@@ -62,11 +67,11 @@ export class CosmosSdkHost {
         },
         (error, response, body) => {
           if (error) {
-            reject(error);
+            reject(JSON.parse(body, Amino.reviver) as ErrorResponse);
             return;
           }
 
-          resolve(JSON.parse(body, Amino.reviver));
+          resolve(JSON.parse(body, Amino.reviver) as T);
         }
       );
     });

--- a/src/common/cosmos-sdk-host.ts
+++ b/src/common/cosmos-sdk-host.ts
@@ -1,6 +1,6 @@
 import * as request from 'request';
 import { StdSignDoc, StdFee } from '../x/auth/stdtx';
-import { Msg } from '../cosmos-sdk/msg';
+import { Msg } from '../cosmos-sdk/tx_msg';
 import { Amino } from '../tendermint/amino';
 
 /**

--- a/src/cosmos-sdk/errors.ts
+++ b/src/cosmos-sdk/errors.ts
@@ -1,0 +1,23 @@
+export type CodeType = number;
+export type CodespaceType = string;
+
+export const ErrorCode = {
+  Ok: 0,
+  Internal: 1,
+  TxDecode: 2,
+  InvalidSequence: 3,
+  Unauthorized: 4,
+  InsufficientFunds: 5,
+  UnknownRequest: 6,
+  InvalidAddress: 7,
+  InvalidPubKey: 8,
+  UnknownAddress: 9,
+  InsufficientCoins: 10,
+  InvalidCoins: 11,
+  OutOfGas: 12,
+  MemoTooLarge: 13,
+  InsufficientFee: 14,
+  TooManySignatures: 15,
+  GasOverflow: 16,
+  NoSignatures: 17
+}

--- a/src/cosmos-sdk/events.ts
+++ b/src/cosmos-sdk/events.ts
@@ -1,0 +1,19 @@
+export interface Attribute {
+  key: string;
+  value?: string;
+}
+
+export const AttributeKey = {
+  action: 'action',
+  module: 'module',
+  sender: 'sender'
+};
+
+export interface StringEvent {
+  type?: string;
+  attributes?: Attribute[];
+}
+
+export const EventType = {
+  message: 'message'
+};

--- a/src/cosmos-sdk/rest.ts
+++ b/src/cosmos-sdk/rest.ts
@@ -19,6 +19,6 @@ export interface BaseReq {
 }
 
 export interface ErrorResponse {
-  code: number;
+  code?: number;
   error: string;
 }

--- a/src/cosmos-sdk/result.ts
+++ b/src/cosmos-sdk/result.ts
@@ -1,0 +1,32 @@
+import { Tx } from "./tx_msg";
+
+export interface ABCIMessageLog {
+  msg_index: number;
+  success: boolean;
+  log: string;
+}
+
+export interface TxResponse {
+  height: bigint;
+  txhash: string;
+  code?: number;
+  data?: string;
+  raw_log?: string;
+  logs: ABCIMessageLog[];
+  info: string;
+  gas_wanted: bigint;
+  gas_used: bigint;
+  events: unknown; //todo
+  codespace: string;
+  tx: Tx;
+  timestamp: string;
+}
+
+export interface SearchTxsResult {
+  total_count: number;
+  count: number;
+  page_number: number;
+  page_total: number;
+  limit: number;
+  txs: TxResponse[];
+}

--- a/src/cosmos-sdk/result.ts
+++ b/src/cosmos-sdk/result.ts
@@ -1,4 +1,5 @@
 import { Tx } from "./tx_msg";
+import { StringEvent } from "./events";
 
 export interface ABCIMessageLog {
   msg_index: number;
@@ -16,7 +17,7 @@ export interface TxResponse {
   info?: string;
   gas_wanted?: bigint;
   gas_used?: bigint;
-  events?: unknown; //todo
+  events?: StringEvent;
   codespace?: string;
   tx?: Tx;
   timestamp?: string;

--- a/src/cosmos-sdk/result.ts
+++ b/src/cosmos-sdk/result.ts
@@ -12,14 +12,14 @@ export interface TxResponse {
   code?: number;
   data?: string;
   raw_log?: string;
-  logs: ABCIMessageLog[];
-  info: string;
-  gas_wanted: bigint;
-  gas_used: bigint;
-  events: unknown; //todo
-  codespace: string;
-  tx: Tx;
-  timestamp: string;
+  logs?: ABCIMessageLog[];
+  info?: string;
+  gas_wanted?: bigint;
+  gas_used?: bigint;
+  events?: unknown; //todo
+  codespace?: string;
+  tx?: Tx;
+  timestamp?: string;
 }
 
 export interface SearchTxsResult {

--- a/src/cosmos-sdk/tx_msg.ts
+++ b/src/cosmos-sdk/tx_msg.ts
@@ -7,3 +7,10 @@
 export interface Msg {
   
 }
+
+/**
+ * 空でよい。
+ */
+export interface Tx {
+
+}

--- a/src/x/auth/auth.ts
+++ b/src/x/auth/auth.ts
@@ -1,6 +1,7 @@
 import { BroadcastReq } from "./broadcast-req";
 import { BaseAccount } from "./account";
 import { CosmosSdkHost } from "../../common/cosmos-sdk-host";
+import { TxResponse, SearchTxsResult } from "../../cosmos-sdk/result";
 
 /**
  * Cosmos SDKにおけるx/authのRest APIをまとめたモジュール。
@@ -12,7 +13,7 @@ export module Auth {
    * @param address 
    */
   export function getAccount(host: CosmosSdkHost, address: string) {
-    return host.get<BaseAccount>(`/auth/accounts/${address}`)
+    return host.get<BaseAccount>(`/auth/accounts/${address}`);
   }
 
   /**
@@ -21,7 +22,7 @@ export module Auth {
    * @param hash 
    */
   export function getTransaction(host: CosmosSdkHost, hash: string) {
-    return host.get<{}>(`/txs/${hash}`)
+    return host.get<TxResponse>(`/txs/${hash}`);
   }
 
   /**
@@ -37,7 +38,7 @@ export module Auth {
       limit?: number;
     }
   ) {
-    return host.get<{}>(`/txs`, params)
+    return host.get<SearchTxsResult>(`/txs`, params);
   }
 
   /**

--- a/src/x/auth/stdtx.ts
+++ b/src/x/auth/stdtx.ts
@@ -1,6 +1,6 @@
 import { Coin } from "../../cosmos-sdk/coin/coin";
 import { PubKey } from "../../tendermint/crypto/crypto";
-import { Msg } from "../../cosmos-sdk/msg";
+import { Msg } from "../../cosmos-sdk/tx_msg";
 import { Amino } from "../../tendermint/amino";
 
 /**

--- a/src/x/bank/msgs.ts
+++ b/src/x/bank/msgs.ts
@@ -1,5 +1,5 @@
 import { Coin } from "../../cosmos-sdk/coin/coin";
-import { Msg } from "../../cosmos-sdk/msg";
+import { Msg } from "../../cosmos-sdk/tx_msg";
 import { AccAddress } from "../../cosmos-sdk/address";
 import { Amino } from "../../tendermint/amino";
 

--- a/src/x/staking/staking.ts
+++ b/src/x/staking/staking.ts
@@ -9,7 +9,7 @@ export module Staking {
    * @param host /staking/delegators/${delegatorAddress}/delegations
    * @param delegatorAddress 
    */
-  export function postDelegations(host: CosmosSdkHost, delegatorAddress: string) {
+  export function postDelegation(host: CosmosSdkHost, delegatorAddress: string) {
     return host.post<{}>(`/staking/delegators/${delegatorAddress}/delegations`, {});
   }
 
@@ -18,7 +18,7 @@ export module Staking {
    * @param host 
    * @param delegatorAddress 
    */
-  export function postUnbondingDelegations(host: CosmosSdkHost, delegatorAddress: string) {
+  export function postUnbondingDelegation(host: CosmosSdkHost, delegatorAddress: string) {
     return host.post<{}>(`/staking/delegators/${delegatorAddress}/unbonding_delegations`, {});
   }
 
@@ -27,7 +27,7 @@ export module Staking {
    * @param host 
    * @param delegatorAddress 
    */
-  export function postTransfer(host: CosmosSdkHost, delegatorAddress: string) {
+  export function postRedelegation(host: CosmosSdkHost, delegatorAddress: string) {
     return host.post<{}>(`/staking/delegators/${delegatorAddress}/redelegations`, {});
   }
 }


### PR DESCRIPTION
x/auth/getTransactionに取り掛かった

x/auth/client/rest/rest.goをみると
```go
r.HandleFunc("/txs/{hash}", QueryTxRequestHandlerFn(cliCtx)).Methods("GET")
```

`QueryTxRequestHandlerFn`はにはモジュール名が明記されてないので同一モジュール内つまり同一フォルダ内にあるとわかる

x/auth/client/rest/query.goにあった

```go
output, err := utils.QueryTx(cliCtx, hashHexStr)

```

outputの型はutilsモジュールの`QueryTx`関数を見れば良いとわかる


x/auth/client/utils/query.goにあった

```go
func QueryTx(cliCtx context.CLIContext, hashHexStr string) (sdk.TxResponse, error)
```

`sdk.TxResponse`なる型であるとわかった

types/result.goにあった

```go
Code      uint32          `json:"code,omitempty"`
```
のように`omitempyy`がある
なのでtsには
```typescript
export interface TxResponse {
  height: bigint;
  txhash: string;
  code?: number;
  ...
}
```
とundefined許容にする

こういう細かな仕様を見落としてはいけない


ついでにgetTransactionsもできた

https://github.com/lcnem/cosmos-sdk-js/issues/2
https://github.com/lcnem/cosmos-sdk-js/issues/3
マージされたらこれらクローズ